### PR TITLE
Add Claude artifact project entry

### DIFF
--- a/projects.js
+++ b/projects.js
@@ -3,6 +3,19 @@
 
 const projects = [
     {
+        title: "Claude Artifact Project",
+        description: "A project shared via a Claude public artifact link.",
+        date: "2026",
+        mediaType: "image",
+        mediaSrc: "https://claude.ai/public/artifacts/6fb2ae85-980f-4e4c-99a8-c07af34b500b",
+        tags: ["Claude", "Artifact", "AI"],
+        fullWriteup: `
+            <h2>Project Overview</h2>
+            <p>This project was shared as a public Claude artifact. View the full artifact here:</p>
+            <p><a href="https://claude.ai/public/artifacts/6fb2ae85-980f-4e4c-99a8-c07af34b500b" target="_blank" rel="noopener noreferrer">Open the artifact</a></p>
+        `
+    },
+    {
         title: "LED Deadmau5 Helmet",
         description: "Custom-built LED helmet featuring WLED addressable RGB strips, sound-reactive lighting, and 3D-printed construction. Powered by a 300W battery with full color control. Sold for $700.",
         date: "2025",


### PR DESCRIPTION
### Motivation
- Add a new project entry to the portfolio for a public Claude artifact provided as a URL.
- Preserve the existing project data format so the project renders in the site modal and project grid.
- Include a direct link to the artifact when the media cannot be included locally.

### Description
- Updated `projects.js` to insert a new project object with `title`, `description`, `date`, `mediaType`, `mediaSrc` (external Claude URL), `tags`, and `fullWriteup` containing a link to the artifact.
- The new entry uses the external `https://claude.ai/public/artifacts/6fb2ae85-980f-4e4c-99a8-c07af34b500b` as the `mediaSrc` so it appears on the project card and modal.
- No other files were changed and the change was committed to the repository.

### Testing
- Served the site locally with `python -m http.server 8000` and loaded `http://127.0.0.1:8000/index.html` to verify the new card renders, which succeeded.
- Captured a Playwright screenshot of the page and saved it as `artifacts/new-project.png` to confirm visual rendering of the new project, which succeeded.
- Attempted to fetch the external Claude artifact (with `curl` and Playwright) to validate the remote media but received HTTP 403 / timeouts, so the external resource could not be validated automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a3a12e288328988beb26fc4f4286)