### PR TITLE
Add URL routing and browser history support for project modals

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script>
+        // GitHub Pages SPA redirect trick
+        // Saves the path so index.html can open the right project
+        sessionStorage.setItem('redirect-path', location.pathname);
+        location.replace('/');
+    </script>
+</head>
+<body></body>
+</html>

--- a/projects.js
+++ b/projects.js
@@ -3,6 +3,7 @@
 
 const projects = [
     {
+        slug: "ski-gear-selector",
         title: "RIDGE — Ski Gear Selector",
         description: "AI-powered ski gear recommender. Enter today's conditions at Sugar Bowl, hit a button, and Claude picks your exact layering kit from your personal inventory — not generic advice, your actual gear.",
         date: "February 2026",
@@ -39,6 +40,7 @@ const projects = [
         `
     },
     {
+        slug: "deadmau5-helmet",
         title: "LED Deadmau5 Helmet",
         description: "Custom-built LED helmet featuring WLED addressable RGB strips, sound-reactive lighting, and 3D-printed construction. Powered by a 300W battery with full color control. Sold for $700.",
         date: "2025",
@@ -97,6 +99,7 @@ const projects = [
         `
     },
     {
+        slug: "sao-many-saos",
         title: "SAO MANY SAOs — DEF CON Badge",
         description: "A large-format SAO host badge supporting 25 SAO connectors simultaneously. Built around SAOv1.69bis standard with dual 18650 batteries, USB charging, and addressable LEDs. Designed, manufactured, and sold at DEF CON.",
         date: "2025",
@@ -154,6 +157,7 @@ const projects = [
         `
     },
     {
+        slug: "frc-cheat-sheet",
         title: "FRC 2026 REBUILT Cheat Sheet",
         description: "Complete strategy and rules reference for FRC 2026 REBUILT game. Comprehensive 3-page cheat sheet covering game mechanics, robot specifications, and Team 5940 BREAD's competitive strategy.",
         date: "January 2026",
@@ -202,6 +206,7 @@ const projects = [
     },
     // Add more projects below - just copy the format above!
     // {
+    //     slug: "your-project-name", // URL-friendly name (used for vortex1.dev/your-project-name)
     //     title: "Your Project Name",
     //     description: "Brief description shown on card",
     //     date: "Month Year",


### PR DESCRIPTION
## Summary
This PR implements URL routing for the portfolio project modals, allowing users to share direct links to specific projects and use browser back/forward navigation. When a project modal is opened, the URL updates to reflect the project slug, and closing the modal returns to the homepage.

## Key Changes
- **URL routing for modals**: Opening a project modal now updates the browser URL to `/{project-slug}` using `history.pushState()`
- **Browser history support**: Added `popstate` event listener to handle back/forward button navigation and restore the appropriate modal state
- **404 redirect handling**: Created `404.html` that captures direct project URL visits and redirects to the homepage while preserving the intended path via `sessionStorage`, allowing the main app to open the correct project
- **Project slugs**: Added `slug` property to all projects in `projects.js` for URL-friendly identifiers
- **Modal parameter**: Updated `openModal()` function to accept optional `skipPush` parameter to prevent duplicate URL updates when navigating via browser history or 404 redirects
- **URL restoration**: Closing a modal restores the URL to the homepage using `history.pushState()`

## Implementation Details
- The `404.html` file uses a redirect trick suitable for GitHub Pages SPAs: it saves the requested path to `sessionStorage` and redirects to the root, allowing `app.js` to detect and handle the redirect
- The `skipPush` parameter prevents URL duplication when opening modals from history navigation or 404 redirects
- `history.replaceState()` is used after 404 redirects to maintain a clean URL history without the intermediate redirect

https://claude.ai/code/session_01RVtNgruJw2igLVFU4bwqyC