### PR TITLE
Replace profile placeholder with favicon image

### DIFF
--- a/about.html
+++ b/about.html
@@ -31,7 +31,7 @@
         <section class="bio-section">
             <div class="bio-content">
                 <div class="bio-image-container">
-                    <img src="media/profile-placeholder.svg" alt="Profile Photo" class="bio-image">
+                    <img src="media/favicon.png" alt="Profile Photo" class="bio-image">
                 </div>
 
                 <div class="bio-text">


### PR DESCRIPTION
## Summary
Updated the About page to use the favicon image instead of a placeholder SVG for the profile photo.

## Changes
- Changed the profile image source from `media/profile-placeholder.svg` to `media/favicon.png` in the bio section of about.html
- The alt text remains unchanged as "Profile Photo" for accessibility

## Details
This change replaces the temporary placeholder graphic with an actual favicon image for the user's profile picture on the About page.

https://claude.ai/code/session_01XqHubNx5FiKw6J3PyTDjd9