### PR TITLE
Fix login form not showing after logout

### DIFF
--- a/account.html
+++ b/account.html
@@ -235,7 +235,7 @@
         var user = Accounts.currentUser();
         if (user) {
             document.getElementById('auth-section').style.display = 'none';
-            document.getElementById('profile-section').style.display = 'block';
+            document.getElementById('profile-section').style.display = '';
             document.getElementById('page-title').textContent = user;
             document.getElementById('page-subtitle').textContent = 'Your account and gear overview';
             renderProfile();
@@ -245,6 +245,7 @@
             document.getElementById('profile-section').style.display = 'none';
             document.getElementById('page-title').textContent = 'Account';
             document.getElementById('page-subtitle').textContent = 'Login or create an account to save your gear';
+            switchTab('login');
             renderUserList('user-list');
         }
     }


### PR DESCRIPTION
After registering (which switches to the Register tab) and then logging out, renderPage() restored the auth section but never reset the tab state. The login form stayed hidden (display:none from switchTab) while the register form remained visible, preventing users from logging in.

Call switchTab('login') in the logged-out branch of renderPage() so the login form and tab are always active when the auth section appears.

Also fix profile section display to use CSS grid layout instead of forcing display:block.

Fixes #20

https://claude.ai/code/session_01FfvmSRT83RC23vd9HN2Pbj