### PR TITLE
Fix favicon paths and update copyright year

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About - Vortex1 Portfolio</title>
     <link rel="stylesheet" href="styles.css">
-    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="icon" type="image/png" href="media/favicon.png">
 </head>
 <body>
     <nav class="top-nav">
@@ -67,7 +67,7 @@
 
     <footer>
         <div class="container">
-            <p>&copy; 2025 Vortex1. All rights reserved.</p>
+            <p>&copy; 2026 Vortex1. All rights reserved.</p>
         </div>
     </footer>
 </body>

--- a/account.html
+++ b/account.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Account - Vortex1</title>
     <link rel="stylesheet" href="styles.css">
-    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="icon" type="image/png" href="media/favicon.png">
 </head>
 <body>
     <nav class="top-nav">

--- a/changelog.html
+++ b/changelog.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Changelog - Vortex1 Portfolio</title>
     <link rel="stylesheet" href="styles.css">
-    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="icon" type="image/png" href="media/favicon.png">
 </head>
 <body>
     <nav class="top-nav">
@@ -31,8 +31,16 @@
         <section class="changelog-section">
             <div class="changelog-list">
                 <div class="changelog-entry">
-                    <span class="changelog-date">02/17/26 @ 23:56</span>
-                    <span class="changelog-text">Merge RIDGE ski gear selector API fixes</span>
+                    <span class="changelog-date">02/19/26 @ 18:00</span>
+                    <span class="changelog-text">Review all recent changes — fix broken favicon paths, about page copyright year, changelog ordering and missing entries</span>
+                </div>
+                <div class="changelog-entry">
+                    <span class="changelog-date">02/19/26 @ 08:30</span>
+                    <span class="changelog-text">Fix login form not showing after logout</span>
+                </div>
+                <div class="changelog-entry">
+                    <span class="changelog-date">02/19/26 @ 06:15</span>
+                    <span class="changelog-text">Update profile image to JA logo on about page</span>
                 </div>
                 <div class="changelog-entry">
                     <span class="changelog-date">02/18/26 @ 07:53</span>
@@ -65,6 +73,10 @@
                 <div class="changelog-entry">
                     <span class="changelog-date">02/18/26 @ 03:52</span>
                     <span class="changelog-text">Add RIDGE ski gear selector app</span>
+                </div>
+                <div class="changelog-entry">
+                    <span class="changelog-date">02/17/26 @ 23:56</span>
+                    <span class="changelog-text">Merge RIDGE ski gear selector API fixes</span>
                 </div>
                 <div class="changelog-entry">
                     <span class="changelog-date">02/05/26 @ 19:57</span>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Vortex1 Portfolio</title>
     <link rel="stylesheet" href="styles.css">
-    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="icon" type="image/png" href="media/favicon.png">
 </head>
 <body>
     <nav class="top-nav">


### PR DESCRIPTION
## Summary
This PR fixes broken favicon references across multiple pages and updates the copyright year in the footer. Additionally, the changelog has been reorganized to correct entry ordering and add missing recent entries.

## Key Changes
- **Favicon path fix**: Updated favicon link references from `favicon.png` to `media/favicon.png` in all HTML files (index.html, about.html, account.html, changelog.html)
- **Copyright year update**: Changed footer copyright year from 2025 to 2026 in about.html
- **Changelog reorganization**: 
  - Reordered changelog entries to be in reverse chronological order (newest first)
  - Added three missing recent entries:
    - 02/19/26 @ 18:00 - Review all recent changes
    - 02/19/26 @ 08:30 - Fix login form not showing after logout
    - 02/19/26 @ 06:15 - Update profile image to JA logo on about page
  - Moved the 02/17/26 @ 23:56 entry to its correct chronological position

## Implementation Details
All favicon references now correctly point to the `media/` subdirectory where the favicon asset is stored. The changelog entries are now properly sorted with the most recent changes appearing at the top of the list.

https://claude.ai/code/session_01FyMGBVacUUcu8gHT1joLmp