### PR TITLE
Add calendar export and 5-minute match notifications to FRC dashboard

### DIFF
--- a/frc.html
+++ b/frc.html
@@ -66,6 +66,7 @@
                     <button id="frc-btn-calendar" class="frc-btn" type="button">Add to Calendar</button>
                     <button id="frc-btn-notify" class="frc-btn" type="button">Enable Notifications</button>
                     <button id="frc-btn-test" class="frc-btn frc-btn-secondary" type="button" title="Fire a sample notification right now so you can verify the alert works on this event.">Send Test Notification</button>
+                    <button id="frc-btn-test-cal" class="frc-btn frc-btn-secondary" type="button" title="Download a single-event .ics scheduled 6 minutes from now. After importing, the 5-minute alarm fires in about 1 minute.">Test Calendar Event</button>
                 </div>
                 <p id="frc-reminders-status" class="frc-reminders-status"></p>
             </div>

--- a/frc.html
+++ b/frc.html
@@ -65,6 +65,7 @@
                 <div class="frc-reminders-actions">
                     <button id="frc-btn-calendar" class="frc-btn" type="button">Add to Calendar</button>
                     <button id="frc-btn-notify" class="frc-btn" type="button">Enable Notifications</button>
+                    <button id="frc-btn-test" class="frc-btn frc-btn-secondary" type="button" title="Fire a sample notification right now so you can verify the alert works on this event.">Send Test Notification</button>
                 </div>
                 <p id="frc-reminders-status" class="frc-reminders-status"></p>
             </div>

--- a/frc.html
+++ b/frc.html
@@ -56,7 +56,7 @@
             </div>
 
             <!-- Calendar & Notifications -->
-            <div id="frc-reminders" class="frc-reminders-card" style="display:none">
+            <div id="frc-reminders" class="frc-reminders-card">
                 <div class="frc-info-icon" data-tooltip="Add upcoming matches to your calendar (with built-in 5-minute alarms) or enable browser notifications that fire 5 minutes before each match with the live stream link.">i</div>
                 <div class="frc-reminders-header">
                     <h3>Match Reminders</h3>

--- a/frc.js
+++ b/frc.js
@@ -594,6 +594,55 @@
         setReminderStatus('Test notification sent. If you do not see it, check your OS notification settings (Do Not Disturb, Focus mode).');
     }
 
+    function downloadTestCalendar() {
+        var sample = pickSampleMatch();
+        var streamUrl = getStreamUrl(currentEventDetails);
+        var viewerUrl = getViewerUrl();
+        var name = sample ? formatMatchName(sample) : 'Sample Match';
+        var alliance = sample ? getTeamAlliance(sample) : null;
+        var now = Date.now();
+        var startMs = now + 6 * 60 * 1000;
+        var endMs = startMs + MATCH_DURATION_MS;
+        var descLines = ['[TEST] FRC 5940 BREAD' + (alliance ? ' on ' + alliance.toUpperCase() + ' alliance' : '') + '. This event is for testing — ignore the time.'];
+        if (streamUrl) descLines.push('Watch live: ' + streamUrl);
+        descLines.push('Dashboard: ' + viewerUrl);
+        var lines = [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//Vortex1//FRC 5940 BREAD//EN',
+            'CALSCALE:GREGORIAN',
+            'METHOD:PUBLISH',
+            'X-WR-CALNAME:' + escapeIcs('FRC 5940 - Calendar Test'),
+            'BEGIN:VEVENT',
+            'UID:test-' + now + '@vortex1.dev',
+            'DTSTAMP:' + icsDate(now),
+            'DTSTART:' + icsDate(startMs),
+            'DTEND:' + icsDate(endMs),
+            'SUMMARY:' + escapeIcs('[TEST] FRC 5940 - ' + name),
+            'DESCRIPTION:' + escapeIcs(descLines.join('\n'))
+        ];
+        if (streamUrl) lines.push('URL:' + streamUrl);
+        lines.push(
+            'BEGIN:VALARM',
+            'TRIGGER:-PT5M',
+            'ACTION:DISPLAY',
+            'DESCRIPTION:' + escapeIcs('[TEST] FRC 5940 plays in 5 minutes - ' + name),
+            'END:VALARM',
+            'END:VEVENT',
+            'END:VCALENDAR'
+        );
+        var blob = new Blob([lines.join('\r\n')], { type: 'text/calendar;charset=utf-8' });
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = 'frc5940-calendar-test.ics';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+        setReminderStatus('Test calendar event downloaded. Import it now — the 5-minute alarm should fire in about 1 minute.');
+    }
+
     function pickSampleMatch() {
         if (!currentMatches.length) return null;
         var upcoming = upcomingMatches(currentMatches);
@@ -804,6 +853,7 @@
         document.getElementById('frc-btn-calendar').addEventListener('click', downloadCalendar);
         document.getElementById('frc-btn-notify').addEventListener('click', toggleNotifications);
         document.getElementById('frc-btn-test').addEventListener('click', sendTestNotification);
+        document.getElementById('frc-btn-test-cal').addEventListener('click', downloadTestCalendar);
 
         loadYear(currentYear).then(function () {
             showLoading(false);

--- a/frc.js
+++ b/frc.js
@@ -478,7 +478,7 @@
             .replace(/\r?\n/g, '\\n');
     }
 
-    function buildIcs(matches, eventDetails) {
+    function buildIcs(matches, eventDetails, includePast) {
         var streamUrl = getStreamUrl(eventDetails);
         var viewerUrl = getViewerUrl();
         var stamp = icsDate(Date.now());
@@ -500,7 +500,15 @@
             'METHOD:PUBLISH',
             'X-WR-CALNAME:' + escapeIcs(calName)
         ];
-        upcomingMatches(matches).forEach(function (m) {
+        var iterMatches;
+        if (includePast) {
+            iterMatches = matches.slice()
+                .filter(function (m) { return matchTime(m) > 0; })
+                .sort(function (a, b) { return matchTime(a) - matchTime(b); });
+        } else {
+            iterMatches = upcomingMatches(matches);
+        }
+        iterMatches.forEach(function (m) {
             var startMs = matchTime(m);
             var endMs = startMs + MATCH_DURATION_MS;
             var name = formatMatchName(m);
@@ -530,12 +538,14 @@
     }
 
     function downloadCalendar() {
-        var matches = upcomingMatches(currentMatches);
+        var upcoming = upcomingMatches(currentMatches);
+        var matches = upcoming.length ? upcoming : currentMatches.slice().sort(function (a, b) { return matchTime(a) - matchTime(b); });
         if (!matches.length) {
-            setReminderStatus('No upcoming matches to add. Schedule may not be released yet.');
+            setReminderStatus('No matches available to export.');
             return;
         }
-        var ics = buildIcs(currentMatches, currentEventDetails);
+        var includePast = upcoming.length === 0;
+        var ics = buildIcs(matches, currentEventDetails, includePast);
         var blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
         var url = URL.createObjectURL(blob);
         var a = document.createElement('a');
@@ -545,7 +555,51 @@
         a.click();
         document.body.removeChild(a);
         setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
-        setReminderStatus('Calendar downloaded — ' + matches.length + ' upcoming match' + (matches.length === 1 ? '' : 'es') + ' with 5-minute alarms.');
+        var label = includePast ? 'past match' : 'upcoming match';
+        setReminderStatus('Calendar downloaded — ' + matches.length + ' ' + label + (matches.length === 1 ? '' : 'es') + ' with 5-minute alarms.');
+    }
+
+    async function sendTestNotification() {
+        if (!('Notification' in window)) {
+            setReminderStatus('This browser does not support notifications.');
+            return;
+        }
+        var perm = Notification.permission;
+        if (perm === 'default') {
+            perm = await Notification.requestPermission();
+        }
+        if (perm !== 'granted') {
+            setReminderStatus('Notification permission denied. Enable it in your browser site settings to test alerts.');
+            return;
+        }
+        var sample = pickSampleMatch();
+        var streamUrl = getStreamUrl(currentEventDetails);
+        var viewerUrl = getViewerUrl();
+        var name = sample ? formatMatchName(sample) : 'Sample Match';
+        var alliance = sample ? getTeamAlliance(sample) : null;
+        var bodyParts = ['[TEST] BREAD plays in 5 minutes' + (alliance ? ' on ' + alliance.toUpperCase() + ' alliance' : '') + '.'];
+        if (streamUrl) bodyParts.push('Watch: ' + streamUrl);
+        bodyParts.push('Dashboard: ' + viewerUrl);
+        var notif = new Notification('FRC 5940 - ' + name + ' (Test)', {
+            body: bodyParts.join('\n'),
+            icon: 'media/favicon.png',
+            tag: 'frc5940-test',
+            requireInteraction: true
+        });
+        notif.onclick = function () {
+            window.focus();
+            if (streamUrl) window.open(streamUrl, '_blank', 'noopener');
+            notif.close();
+        };
+        setReminderStatus('Test notification sent. If you do not see it, check your OS notification settings (Do Not Disturb, Focus mode).');
+    }
+
+    function pickSampleMatch() {
+        if (!currentMatches.length) return null;
+        var upcoming = upcomingMatches(currentMatches);
+        if (upcoming.length) return upcoming[0];
+        var sorted = currentMatches.slice().sort(function (a, b) { return matchTime(b) - matchTime(a); });
+        return sorted[0];
     }
 
     function clearScheduledNotifications() {
@@ -749,6 +803,7 @@
 
         document.getElementById('frc-btn-calendar').addEventListener('click', downloadCalendar);
         document.getElementById('frc-btn-notify').addEventListener('click', toggleNotifications);
+        document.getElementById('frc-btn-test').addEventListener('click', sendTestNotification);
 
         loadYear(currentYear).then(function () {
             showLoading(false);

--- a/styles.css
+++ b/styles.css
@@ -1255,6 +1255,17 @@ footer {
     box-shadow: 0 0 12px rgba(0, 255, 136, 0.5);
 }
 
+.frc-btn.frc-btn-secondary {
+    border-color: #555;
+    color: #a0a0a0;
+}
+
+.frc-btn.frc-btn-secondary:hover:not(:disabled) {
+    background: #2a2a2a;
+    color: #fff;
+    box-shadow: none;
+}
+
 .frc-reminders-status {
     margin: 12px 0 0;
     font-size: 0.82rem;


### PR DESCRIPTION
## Summary
- New **Match Reminders** card on the FRC 5940 dashboard with four actions: Add to Calendar, Enable Notifications, Send Test Notification, Test Calendar Event.
- **Add to Calendar** downloads an `.ics` file with every upcoming match. Each `VEVENT` carries a `VALARM` with `TRIGGER:-PT5M` and a description containing the YouTube live stream link plus the dashboard URL — so any calendar app fires its own native 5-minute alert.
- **Enable Notifications** uses the browser Notification API. For every upcoming match, a `setTimeout` is scheduled for `match_start − 5 min`; when it fires, the notification shows the match name, alliance color, the YouTube watch link, and the dashboard link. Clicking opens the stream. Preference persists in `localStorage` and re-schedules on every refresh.
- Two **test buttons** so the flow can be validated against any event (including past ones): Send Test Notification fires a sample alert immediately using the selected event's stream URL; Test Calendar Event downloads a one-shot `.ics` scheduled ~6 minutes in the future so the calendar app's native 5-minute alarm fires about a minute after import.

## Test plan
- [ ] Load `frc.html`, confirm the "Match Reminders" card appears between the controls and the live stream.
- [ ] On a 2025 (past) event, click **Send Test Notification** → grant permission → verify the notification appears with the YouTube link and clicking it opens the stream.
- [ ] On a 2025 event, click **Test Calendar Event** → import the downloaded `.ics` into Google/Apple/Outlook → verify the alarm fires ~1 minute later with the YouTube link visible in the description.
- [ ] On an event with the schedule released, click **Add to Calendar** → confirm `.ics` contains one `VEVENT` per upcoming match, each with a `VALARM` and the stream/dashboard links.
- [ ] Toggle **Enable Notifications** off → confirm button label updates and no notifications fire.

https://claude.ai/code/session_01Hp2fqP62Kkh3tecpyEf6q8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp2fqP62Kkh3tecpyEf6q8)_