### PR TITLE
Add Google Calendar quick-add button (missed in PR #39)

### DIFF
--- a/frc.html
+++ b/frc.html
@@ -64,6 +64,7 @@
                 </div>
                 <div class="frc-reminders-actions">
                     <button id="frc-btn-calendar" class="frc-btn" type="button">Add to Calendar</button>
+                    <button id="frc-btn-google" class="frc-btn" type="button" title="Open Google Calendar with the next match pre-filled. For all matches at once, use Add to Calendar.">Add Next to Google Calendar</button>
                     <button id="frc-btn-notify" class="frc-btn" type="button">Enable Notifications</button>
                     <button id="frc-btn-test" class="frc-btn frc-btn-secondary" type="button" title="Fire a sample notification right now so you can verify the alert works on this event.">Send Test Notification</button>
                     <button id="frc-btn-test-cal" class="frc-btn frc-btn-secondary" type="button" title="Download a single-event .ics scheduled 6 minutes from now. After importing, the 5-minute alarm fires in about 1 minute.">Test Calendar Event</button>

--- a/frc.js
+++ b/frc.js
@@ -595,16 +595,19 @@
     }
 
     function googleCalendarUrl(match, eventDetails) {
-        var startMs = matchTime(match);
-        var endMs = startMs + MATCH_DURATION_MS;
+        var matchStartMs = matchTime(match);
+        var startMs = matchStartMs - NOTIFY_LEAD_MS;
+        var endMs = matchStartMs + MATCH_DURATION_MS;
         var name = formatMatchName(match);
         var alliance = getTeamAlliance(match);
         var streamUrl = getStreamUrl(eventDetails);
         var viewerUrl = getViewerUrl();
-        var detailLines = ['FRC 5940 BREAD' + (alliance ? ' on ' + alliance.toUpperCase() + ' alliance' : '') + '.'];
+        var detailLines = [
+            'FRC 5940 BREAD' + (alliance ? ' on ' + alliance.toUpperCase() + ' alliance' : '') + '.',
+            'Match starts at ' + formatTime(matchStartMs / 1000) + ' — this event is set 5 minutes early as your heads-up.'
+        ];
         if (streamUrl) detailLines.push('Watch live: ' + streamUrl);
         detailLines.push('Dashboard: ' + viewerUrl);
-        detailLines.push('Tip: set a 5-minute reminder in Google Calendar so you do not miss the start.');
         var locParts = [];
         if (eventDetails) {
             if (eventDetails.name) locParts.push(eventDetails.name);
@@ -614,7 +617,7 @@
         }
         var params = new URLSearchParams({
             action: 'TEMPLATE',
-            text: 'FRC 5940 - ' + name,
+            text: 'FRC 5940 - ' + name + ' (5 min warning)',
             dates: icsDate(startMs) + '/' + icsDate(endMs),
             details: detailLines.join('\n'),
             location: locParts.join(', ')
@@ -632,7 +635,7 @@
         window.open(url, '_blank', 'noopener');
         var upcoming = upcomingMatches(currentMatches);
         var label = upcoming.length ? 'next match' : 'most recent match';
-        setReminderStatus('Opened Google Calendar for the ' + label + ' (' + formatMatchName(match) + '). Google does not carry the 5-minute alarm — set it manually or use Add to Calendar for the .ics import.');
+        setReminderStatus('Opened Google Calendar for the ' + label + ' (' + formatMatchName(match) + '). Event is scheduled 5 minutes before kickoff so it doubles as your reminder.');
     }
 
     function downloadTestCalendar() {

--- a/frc.js
+++ b/frc.js
@@ -594,6 +594,47 @@
         setReminderStatus('Test notification sent. If you do not see it, check your OS notification settings (Do Not Disturb, Focus mode).');
     }
 
+    function googleCalendarUrl(match, eventDetails) {
+        var startMs = matchTime(match);
+        var endMs = startMs + MATCH_DURATION_MS;
+        var name = formatMatchName(match);
+        var alliance = getTeamAlliance(match);
+        var streamUrl = getStreamUrl(eventDetails);
+        var viewerUrl = getViewerUrl();
+        var detailLines = ['FRC 5940 BREAD' + (alliance ? ' on ' + alliance.toUpperCase() + ' alliance' : '') + '.'];
+        if (streamUrl) detailLines.push('Watch live: ' + streamUrl);
+        detailLines.push('Dashboard: ' + viewerUrl);
+        detailLines.push('Tip: set a 5-minute reminder in Google Calendar so you do not miss the start.');
+        var locParts = [];
+        if (eventDetails) {
+            if (eventDetails.name) locParts.push(eventDetails.name);
+            if (eventDetails.city) locParts.push(eventDetails.city);
+            if (eventDetails.state_prov) locParts.push(eventDetails.state_prov);
+            if (eventDetails.country) locParts.push(eventDetails.country);
+        }
+        var params = new URLSearchParams({
+            action: 'TEMPLATE',
+            text: 'FRC 5940 - ' + name,
+            dates: icsDate(startMs) + '/' + icsDate(endMs),
+            details: detailLines.join('\n'),
+            location: locParts.join(', ')
+        });
+        return 'https://calendar.google.com/calendar/render?' + params.toString();
+    }
+
+    function openGoogleCalendar() {
+        var match = pickSampleMatch();
+        if (!match) {
+            setReminderStatus('No match available to add.');
+            return;
+        }
+        var url = googleCalendarUrl(match, currentEventDetails);
+        window.open(url, '_blank', 'noopener');
+        var upcoming = upcomingMatches(currentMatches);
+        var label = upcoming.length ? 'next match' : 'most recent match';
+        setReminderStatus('Opened Google Calendar for the ' + label + ' (' + formatMatchName(match) + '). Google does not carry the 5-minute alarm — set it manually or use Add to Calendar for the .ics import.');
+    }
+
     function downloadTestCalendar() {
         var sample = pickSampleMatch();
         var streamUrl = getStreamUrl(currentEventDetails);
@@ -851,6 +892,7 @@
         });
 
         document.getElementById('frc-btn-calendar').addEventListener('click', downloadCalendar);
+        document.getElementById('frc-btn-google').addEventListener('click', openGoogleCalendar);
         document.getElementById('frc-btn-notify').addEventListener('click', toggleNotifications);
         document.getElementById('frc-btn-test').addEventListener('click', sendTestNotification);
         document.getElementById('frc-btn-test-cal').addEventListener('click', downloadTestCalendar);


### PR DESCRIPTION
## Summary
The Google Calendar quick-add button commits (`4f40a00`, `42b3016`) were pushed to the `claude/add-calendar-notifications-6aq3X` branch after PR #39 was merged at `daff3e0`, so they never landed on main. This PR brings them across.

- **Add Next to Google Calendar** button opens `calendar.google.com/calendar/render` for the next upcoming match (or most recent past match) pre-filled with title, times, location, YouTube link, and dashboard URL.
- Event is scheduled 5 minutes before match start (since Google's render URL doesn't carry `VALARM`), so the calendar entry itself acts as the heads-up.

## Test plan
- [ ] Hard-refresh `frc.html` and confirm a 5th button appears: "Add Next to Google Calendar".
- [ ] Click it → Google Calendar opens with the event pre-filled and `DTSTART = matchTime − 5 min`.

https://claude.ai/code/session_01Hp2fqP62Kkh3tecpyEf6q8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp2fqP62Kkh3tecpyEf6q8)_