### PR TITLE
Add Test Google Calendar button

### DIFF
--- a/frc.html
+++ b/frc.html
@@ -68,6 +68,7 @@
                     <button id="frc-btn-notify" class="frc-btn" type="button">Enable Notifications</button>
                     <button id="frc-btn-test" class="frc-btn frc-btn-secondary" type="button" title="Fire a sample notification right now so you can verify the alert works on this event.">Send Test Notification</button>
                     <button id="frc-btn-test-cal" class="frc-btn frc-btn-secondary" type="button" title="Download a single-event .ics scheduled 6 minutes from now. After importing, the 5-minute alarm fires in about 1 minute.">Test Calendar Event</button>
+                    <button id="frc-btn-test-google" class="frc-btn frc-btn-secondary" type="button" title="Open Google Calendar with a sample event timed so it appears on your calendar in about 1 minute.">Test Google Calendar</button>
                 </div>
                 <p id="frc-reminders-status" class="frc-reminders-status"></p>
             </div>

--- a/frc.js
+++ b/frc.js
@@ -638,6 +638,39 @@
         setReminderStatus('Opened Google Calendar for the ' + label + ' (' + formatMatchName(match) + '). Event is scheduled 5 minutes before kickoff so it doubles as your reminder.');
     }
 
+    function openTestGoogleCalendar() {
+        var sample = pickSampleMatch();
+        var streamUrl = getStreamUrl(currentEventDetails);
+        var viewerUrl = getViewerUrl();
+        var name = sample ? formatMatchName(sample) : 'Sample Match';
+        var alliance = sample ? getTeamAlliance(sample) : null;
+        var now = Date.now();
+        var matchStartMs = now + 6 * 60 * 1000;
+        var startMs = matchStartMs - NOTIFY_LEAD_MS;
+        var endMs = matchStartMs + MATCH_DURATION_MS;
+        var detailLines = [
+            '[TEST] FRC 5940 BREAD' + (alliance ? ' on ' + alliance.toUpperCase() + ' alliance' : '') + '. This event is for testing — ignore the time.'
+        ];
+        if (streamUrl) detailLines.push('Watch live: ' + streamUrl);
+        detailLines.push('Dashboard: ' + viewerUrl);
+        var locParts = [];
+        if (currentEventDetails) {
+            if (currentEventDetails.name) locParts.push(currentEventDetails.name);
+            if (currentEventDetails.city) locParts.push(currentEventDetails.city);
+            if (currentEventDetails.state_prov) locParts.push(currentEventDetails.state_prov);
+            if (currentEventDetails.country) locParts.push(currentEventDetails.country);
+        }
+        var params = new URLSearchParams({
+            action: 'TEMPLATE',
+            text: '[TEST] FRC 5940 - ' + name + ' (5 min warning)',
+            dates: icsDate(startMs) + '/' + icsDate(endMs),
+            details: detailLines.join('\n'),
+            location: locParts.join(', ')
+        });
+        window.open('https://calendar.google.com/calendar/render?' + params.toString(), '_blank', 'noopener');
+        setReminderStatus('Opened Google Calendar with a test event. Save it — the entry will appear on your calendar in about 1 minute.');
+    }
+
     function downloadTestCalendar() {
         var sample = pickSampleMatch();
         var streamUrl = getStreamUrl(currentEventDetails);
@@ -899,6 +932,7 @@
         document.getElementById('frc-btn-notify').addEventListener('click', toggleNotifications);
         document.getElementById('frc-btn-test').addEventListener('click', sendTestNotification);
         document.getElementById('frc-btn-test-cal').addEventListener('click', downloadTestCalendar);
+        document.getElementById('frc-btn-test-google').addEventListener('click', openTestGoogleCalendar);
 
         loadYear(currentYear).then(function () {
             showLoading(false);


### PR DESCRIPTION
## Summary
Adds a **Test Google Calendar** button alongside the existing Test Calendar Event button. Opens `calendar.google.com` with a sample event timed so the calendar entry appears in about 1 minute (synthetic match start = `now + 6 min`, then shifted 5 min earlier per the existing Google flow).

## Test plan
- [ ] Hard-refresh `frc.html`, click **Test Google Calendar**.
- [ ] Verify Google Calendar opens with a `[TEST] FRC 5940 - ... (5 min warning)` event pre-filled, scheduled ~1 minute from now.
- [ ] Save it and confirm the entry shows up on your calendar.

https://claude.ai/code/session_01Hp2fqP62Kkh3tecpyEf6q8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp2fqP62Kkh3tecpyEf6q8)_