### PR TITLE
Add bulk "Add All to Google Calendar" button

### DIFF
--- a/frc.html
+++ b/frc.html
@@ -64,7 +64,8 @@
                 </div>
                 <div class="frc-reminders-actions">
                     <button id="frc-btn-calendar" class="frc-btn" type="button">Add to Calendar</button>
-                    <button id="frc-btn-google" class="frc-btn" type="button" title="Open Google Calendar with the next match pre-filled. For all matches at once, use Add to Calendar.">Add Next to Google Calendar</button>
+                    <button id="frc-btn-google-all" class="frc-btn" type="button" title="Download the full match schedule and open Google Calendar's import page so you can upload it in two clicks.">Add All to Google Calendar</button>
+                    <button id="frc-btn-google" class="frc-btn" type="button" title="Open Google Calendar with the next match pre-filled. For all matches at once, use Add All to Google Calendar.">Add Next to Google Calendar</button>
                     <button id="frc-btn-notify" class="frc-btn" type="button">Enable Notifications</button>
                     <button id="frc-btn-test" class="frc-btn frc-btn-secondary" type="button" title="Fire a sample notification right now so you can verify the alert works on this event.">Send Test Notification</button>
                     <button id="frc-btn-test-cal" class="frc-btn frc-btn-secondary" type="button" title="Download a single-event .ics scheduled 6 minutes from now. After importing, the 5-minute alarm fires in about 1 minute.">Test Calendar Event</button>

--- a/frc.js
+++ b/frc.js
@@ -638,6 +638,18 @@
         setReminderStatus('Opened Google Calendar for the ' + label + ' (' + formatMatchName(match) + '). Event is scheduled 5 minutes before kickoff so it doubles as your reminder.');
     }
 
+    function addAllToGoogleCalendar() {
+        var upcoming = upcomingMatches(currentMatches);
+        var matches = upcoming.length ? upcoming : currentMatches.slice().sort(function (a, b) { return matchTime(a) - matchTime(b); });
+        if (!matches.length) {
+            setReminderStatus('No matches available to add.');
+            return;
+        }
+        downloadCalendar();
+        window.open('https://calendar.google.com/calendar/u/0/r/settings/export', '_blank', 'noopener');
+        setReminderStatus('Downloaded ' + matches.length + ' match' + (matches.length === 1 ? '' : 'es') + ' and opened Google Calendar. Scroll to "Import" in the new tab and select the .ics file — the 5-minute alarms will carry through.');
+    }
+
     function openTestGoogleCalendar() {
         var sample = pickSampleMatch();
         var streamUrl = getStreamUrl(currentEventDetails);
@@ -929,6 +941,7 @@
 
         document.getElementById('frc-btn-calendar').addEventListener('click', downloadCalendar);
         document.getElementById('frc-btn-google').addEventListener('click', openGoogleCalendar);
+        document.getElementById('frc-btn-google-all').addEventListener('click', addAllToGoogleCalendar);
         document.getElementById('frc-btn-notify').addEventListener('click', toggleNotifications);
         document.getElementById('frc-btn-test').addEventListener('click', sendTestNotification);
         document.getElementById('frc-btn-test-cal').addEventListener('click', downloadTestCalendar);


### PR DESCRIPTION
## Summary
Adds an **Add All to Google Calendar** button. Google's render URL is single-event-only, so for bulk import we:
1. Download the existing `.ics` (one VEVENT per match, each with a 5-minute VALARM).
2. Open `calendar.google.com/.../settings/export` in a new tab — the same page hosts the **Import** section.

User uploads the file there; alarms carry through unchanged.

## Test plan
- [ ] Click **Add All to Google Calendar** on an event with a released schedule.
- [ ] Verify `.ics` downloads and a Google Calendar Settings tab opens.
- [ ] Scroll to the Import section in the new tab, upload the file, confirm all matches appear with 5-min alarms.

https://claude.ai/code/session_01Hp2fqP62Kkh3tecpyEf6q8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp2fqP62Kkh3tecpyEf6q8)_